### PR TITLE
Remove password from user registration webhook

### DIFF
--- a/includes/outbound-events.php
+++ b/includes/outbound-events.php
@@ -617,12 +617,13 @@ class OutboundEvents{
 					if ( is_array( $_POST ) ) {
 						$register_data = array();
 						foreach( $_POST as $key => $posted_value ) {
-							if ( strpos( $key, 'password' ) != true ) {
+							if ( strpos( $key, 'password' ) === false ) {
 								$register_data[$key] = sanitize_text_field( $posted_value );
 							}
 						}
 
 						unset( $register_data['user_pass'] );
+						unset( $register_data['password'] );
 						unset( $register_data['_wpnonce'] );
 						unset( $register_data['_wp_http_referer'] );
 						$data['registration_fields'] = $register_data;

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Donate link: https://yoohooplugins.com
 Requires at least: 5.0
 Tested up to: 5.9
 Requires PHP: 7.2
-Stable tag: trunk
+Stable tag: 2.4.1
 License: GPL 2.1
 
 Automate your WordPress website with thousands of applications.
@@ -23,6 +23,10 @@ Sync your WordPress user base with Zapier and connect with over 1000+ applicatio
 Yes this will work for any service such as automate.io, if they support posting data to webhooks.
 
 == Changelog ==
+
+= 2.4.1 - Security Fix =
+* SECURITY FIX: Patched a vulnerability where the user's plain-text password could be sent to the webhook during the user_register event.
+
 = 2.4 - TBD =
 * ENHANCEMENT: Added support for MailPoet (Outbound Events)
 * ENHANCEMENT: Removed user's password from Outbound Events.

--- a/wp-zapier.php
+++ b/wp-zapier.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://yoohooplugins.com
  * Author: Yoohoo Plugins
  * Author URI: https://yoohooplugins.com
- * Version: 2.4
+ * Version: 2.4.1
  * License: GPL2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain: wp-zapier


### PR DESCRIPTION
resolves the security vulnerability reported in support ticket #3313.

  Problem:
  A critical security issue was identified where the plugin sends the user's plain-text password in the data
  payload to the configured webhook during the user_register event.

  The root cause was an incorrect logical check in the hydrate() function (includes/outbound-events.php) that
  failed to properly identify and filter out form fields containing the word "password".

  Solution:
  This patch corrects the vulnerability by:
   1. Changing the strpos() comparison from != true to a strict === false. This now correctly identifies and excludes
      any $_POST key that contains "password".
   2. Adding an explicit unset() for password in addition to the existing user_pass as a redundant security measure.